### PR TITLE
Change name of drush phar to 'drush'.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN git clone https://github.com/nikic/php-ast.git \
 #install drush, to use for site and module installs
 RUN curl -L -o drush.phar $(curl -s  https://api.github.com/repos/drush-ops/drush/releases/latest | grep drush/releases/download | cut -d '"' -f 4) \
   && chmod +x drush.phar \
-  && mv drush.phar /usr/local/bin
+  && mv drush.phar /usr/local/bin/drush
 
 # Register the COMPOSER_HOME environment variable
 ENV COMPOSER_HOME /composer

--- a/php7/Dockerfile
+++ b/php7/Dockerfile
@@ -24,7 +24,7 @@ RUN git clone https://github.com/nikic/php-ast.git \
 #install drush, to use for site and module installs
 RUN curl -L -o drush.phar $(curl -s  https://api.github.com/repos/drush-ops/drush/releases/latest | grep drush/releases/download | cut -d '"' -f 4) \
   && chmod +x drush.phar \
-  && mv drush.phar /usr/local/bin
+  && mv drush.phar /usr/local/bin/drush
 
 # Register the COMPOSER_HOME environment variable
 ENV COMPOSER_HOME /composer


### PR DESCRIPTION
`drush` doesn't work in scripts since the file is named `drush.phar`. This matches how you'd use it in other images we use and in this project's php5.6 image.