### PR TITLE
Install the latest chrome and chromedriver from Google

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,26 @@ RUN a2enmod rewrite
 
 # install the PHP extensions we need
 
-RUN apt-get update && apt-get install -y gnupg libpng-dev libjpeg-dev libpq-dev mysql-client git libbz2-dev libgmp-dev libxml2-dev acl chromedriver
+RUN apt-get update && apt-get install -y gnupg libpng-dev libjpeg-dev libpq-dev mysql-client git libbz2-dev libgmp-dev libxml2-dev acl unzip
 RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr
 RUN docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip bcmath bz2 gmp soap
 
 RUN echo 'sendmail_path=/bin/true' > /usr/local/etc/php/conf.d/sendmail.ini
+
+#install latest chrome
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+RUN apt-get update && apt-get install -y google-chrome-stable
+
+#install chromedriver
+RUN CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` \
+  && wget -N http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P ~/ \
+  && unzip ~/chromedriver_linux64.zip -d ~/ \
+  && rm ~/chromedriver_linux64.zip \
+  && mv -f ~/chromedriver /usr/local/bin/chromedriver \
+  && chmod 0755 /usr/local/bin/chromedriver
 
 #install phan dependencies
 RUN git clone https://github.com/nikic/php-ast.git \

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -3,7 +3,7 @@ FROM php:5.6-apache
 RUN a2enmod rewrite
 
 # install the PHP extensions we need
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev mysql-client git libbz2-dev libgmp-dev acl chromedriver \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev mysql-client git libbz2-dev libgmp-dev acl unzip \
   && ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/local/include/ \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
@@ -11,6 +11,19 @@ RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev mysq
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip bcmath bz2 gmp
 
 RUN echo 'sendmail_path=/bin/true' > /usr/local/etc/php/conf.d/sendmail.ini
+
+#install latest chrome
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+RUN apt-get update && apt-get install -y google-chrome-stable
+
+#install chromedriver
+RUN CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` \
+  && wget -N http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P ~/ \
+  && unzip ~/chromedriver_linux64.zip -d ~/ \
+  && rm ~/chromedriver_linux64.zip \
+  && mv -f ~/chromedriver /usr/local/bin/chromedriver \
+  && chmod 0755 /usr/local/bin/chromedriver
 
 #install drush, to use for site and module installs
 RUN php -r "readfile('https://s3.amazonaws.com/files.drush.org/drush.phar');" > drush \

--- a/php7/Dockerfile
+++ b/php7/Dockerfile
@@ -3,13 +3,26 @@ FROM php:7.1-apache
 RUN a2enmod rewrite
 
 # install the PHP extensions we need
-RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libpq-dev mysql-client git libbz2-dev libgmp-dev acl chromedriver
+RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libpq-dev mysql-client git libbz2-dev libgmp-dev acl unzip
 RUN apt-get update && apt-get install -y gnupg
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr
 RUN docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip bcmath bz2 gmp
 
 RUN echo 'sendmail_path=/bin/true' > /usr/local/etc/php/conf.d/sendmail.ini
+
+#install latest chrome
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+RUN apt-get update && apt-get install -y google-chrome-stable
+
+#install chromedriver
+RUN CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` \
+  && wget -N http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P ~/ \
+  && unzip ~/chromedriver_linux64.zip -d ~/ \
+  && rm ~/chromedriver_linux64.zip \
+  && mv -f ~/chromedriver /usr/local/bin/chromedriver \
+  && chmod 0755 /usr/local/bin/chromedriver
 
 #install phan dependencies
 RUN git clone https://github.com/nikic/php-ast.git \


### PR DESCRIPTION
Turns out that the PHP5.6 container doesn't have a very up-to-date chromedriver so installing via apt-get doesn't work very well. So let's install direct from Google and also use the latest stable chrome version. This should result in less issues.