### PR TITLE
Add shellcheck.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,9 @@ RUN curl -sL http://get.sensiolabs.org/security-checker.phar -o security-checker
   && chmod +x security-checker.phar \
   && mv security-checker.phar /usr/local/bin/security-checker
 
-# Xdebug requires beta to support PHP 7.2.
 RUN pecl install xdebug \
     && echo "zend_extension=$(find / -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini
 
 RUN curl -sS https://platform.sh/cli/installer | php
+
+RUN apt-get install shellcheck

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -84,3 +84,5 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && apt-get update && apt-get install yarn
 
 RUN curl -sS https://platform.sh/cli/installer | php
+
+RUN apt-get install shellcheck

--- a/php7/Dockerfile
+++ b/php7/Dockerfile
@@ -103,3 +103,5 @@ RUN pecl install xdebug \
     && echo "zend_extension=$(find / -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini
 
 RUN curl -sS https://platform.sh/cli/installer | php
+
+RUN apt-get install shellcheck


### PR DESCRIPTION
This adds shellcheck to all containers. I build the latest one to verify that the command is available and works as expected.

This also removes a comment about xdebug beta that no longer applies.