### PR TITLE
Use Symfony security checker

### DIFF
--- a/php7.4-composer-1/Dockerfile
+++ b/php7.4-composer-1/Dockerfile
@@ -86,10 +86,9 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update && apt-get install yarn
 
-# Install SensioLabs' security advisories checker
-RUN curl -sL http://get.sensiolabs.org/security-checker.phar -o security-checker.phar \
-  && chmod +x security-checker.phar \
-  && mv security-checker.phar /usr/local/bin/security-checker
+# Install Symfony to use security checker
+RUN curl -sS https://get.symfony.com/cli/installer | bash \
+  && mv /root/.symfony/bin/symfony /usr/local/bin/symfony
 
 RUN curl -sS https://platform.sh/cli/installer | php
 


### PR DESCRIPTION
Replaces security checker that no longer works.

Out of curiosity, does this Dockerfile get used by a lot of projects? I noticed that the Platform.sh CLI is being installed, which we don't need for our specific project. I don't see any issues with leaving it in, however.